### PR TITLE
adds GetStats to return anonymous object of statistics

### DIFF
--- a/src/Parallafka/IParallafka.cs
+++ b/src/Parallafka/IParallafka.cs
@@ -8,6 +8,12 @@ namespace Parallafka
     public interface IParallafka<TKey, TValue>
     {
         /// <summary>
+        /// Returns an anonymous type instance of statistics for the parallafka running instance
+        /// </summary>
+        /// <returns></returns>
+        object GetStats();
+
+        /// <summary>
         /// Continues consuming messages until the stopToken is cancelled
         /// </summary>
         /// <param name="messageHandlerAsync">The delegate that receives the message</param>

--- a/src/Parallafka/MessageRouter.cs
+++ b/src/Parallafka/MessageRouter.cs
@@ -11,8 +11,11 @@ namespace Parallafka
         private readonly MessagesByKey<TKey, TValue> _messageByKey;
         private readonly CancellationToken _stopToken;
 
-
         private readonly BufferBlock<IKafkaMessage<TKey, TValue>> _messagesToHandle;
+        private long _messagesRouted;
+        private long _messagesSkipped;
+        private long _messagesHandled;
+        private long _messagesNotHandled;
 
         public MessageRouter(
             CommitState<TKey, TValue> commitState,
@@ -28,20 +31,40 @@ namespace Parallafka
             });
         }
 
+        public object GetStats()
+        {
+            return new
+            {
+                MessagesRouted = this._messagesRouted,
+                MessagesHandled = this._messagesHandled,
+                MessagesNotHandled = this._messagesNotHandled,
+                MessagesSkipped = this._messagesSkipped,
+                IncomingQueueSize = this._messagesToHandle.Count
+            };
+        }
+
         public ISourceBlock<IKafkaMessage<TKey, TValue>> MessagesToHandle => this._messagesToHandle;
 
         public async Task RouteMessage(IKafkaMessage<TKey, TValue> message)
         {
+            Interlocked.Increment(ref _messagesRouted);
+
             await this._commitState.EnqueueMessageAsync(message);
 
             if (!this._messageByKey.TryAddMessageToHandle(message))
             {
+                Interlocked.Increment(ref _messagesSkipped);
                 return;
             }
 
             if (!await this._messagesToHandle.SendAsync(message, this._stopToken))
             {
+                Interlocked.Increment(ref _messagesNotHandled);
                 Parallafka<TKey, TValue>.WriteLine($"MR: {message.Key} {message.Offset} SendAsync failed!");
+            }
+            else
+            {
+                Interlocked.Increment(ref _messagesHandled);
             }
         }
     }

--- a/src/Parallafka/MessagesByKey.cs
+++ b/src/Parallafka/MessagesByKey.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Parallafka.KafkaConsumer;
 
@@ -23,6 +24,17 @@ namespace Parallafka
             this._messagesToHandleForKey = new();
             this._completedSource = new();
             this.Completion = this._completedSource.Task;
+        }
+
+        public object GetStats()
+        {
+            lock (this._messagesToHandleForKey)
+            {
+                return new
+                {
+                    MessageCountsByKey = this._messagesToHandleForKey.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.Count ?? 0)
+                };
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
You can get stats that when serialized over JSON, look like this:

```json
{
  "ConsumerState": "Polling for Kafka messages",
  "MaxQueuedMessages": 1000,
  "CallDuration": "0:00:05.3857492",
  "CallDurationMs": 5385,
  "CommitState": [
    {
      "Partition": 1,
      "CommitsPending": 0
    },
    {
      "Partition": 0,
      "CommitsPending": 18
    }
  ],
  "MessagesByKey": {
    "MessageCountsByKey": {
      "21568756": 0,
      "21568776": 0,
      "21568780": 0,
      "21568781": 0,
      "21568785": 0,
      "21568787": 0,
      "21568793": 0,
      "21568794": 0
    }
  },
  "Router": {
    "MessagesRouted": 2287,
    "MessagesHandled": 2286,
    "MessagesNotHandled": 0,
    "MessagesSkipped": 0,
    "IncomingQueueSize": 0
  },
  "RoutingTarget": {
    "InputCount": 0,
    "TaskStatus": "WaitingForActivation"
  },
  "FinishedRouter": {
    "InputCount": 0,
    "MessagesHandled": 2278,
    "MessagesSent": 0,
    "MessagesNotSent": 0,
    "MessagesSkipped": 2278
  },
  "Handler": {
    "InputCount": 0,
    "MessagesHandled": 2286,
    "MessagesSent": 2278,
    "MessagesNotSent": 0,
    "MessagesErrored": 0
  },
  "HandlerTarget": {
    "InputCount": 0,
    "TaskStatus": "WaitingForActivation"
  },
  "Committer": {
    "InputCount": 1,
    "MessageCommitLoopInProgress": true,
    "MessagesCommitted": 87,
    "MessagesCommitErrors": 0,
    "MessagesCommitLoops": 134
  },
  "CommitterTarget": {
    "InputCount": 0,
    "TaskStatus": "WaitingForActivation"
  },
  "MessageHandledTarget": {
    "InputCount": 0,
    "TaskStatus": "WaitingForActivation"
  }
}
```