### PR TITLE
support a commit Delay or ASAP commit.

### DIFF
--- a/src/Adapters/ConfluentKafkaAdapter/ConfluentConsumerAdapter.cs
+++ b/src/Adapters/ConfluentKafkaAdapter/ConfluentConsumerAdapter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
@@ -56,7 +55,7 @@ namespace Parallafka.Adapters.ConfluentKafka
                 }
             }
 
-            IKafkaMessage<TKey, TValue> msg = new KafkaMessage<TKey, TValue>(
+            IKafkaMessage<TKey, TValue> msg = KafkaMessage.Create(
                 result.Message.Key,
                 result.Message.Value,
                 new RecordOffset(result.Partition, result.Offset));

--- a/src/Parallafka/CommitPoller.cs
+++ b/src/Parallafka/CommitPoller.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Parallafka
+{
+    /// <summary>
+    /// Performs commits when needed, or on a delay
+    /// </summary>
+    internal class CommitPoller
+    {
+        private readonly IMessageCommitter _committer;
+        private readonly CancellationTokenSource _cancellation;
+        private readonly CancellationToken _cancellationToken;
+
+        private string _state;
+        private bool _complete;
+
+        public CommitPoller(IMessageCommitter committer)
+        {
+            this._committer = committer;
+            this._cancellation = new CancellationTokenSource();
+            this._cancellationToken = _cancellation.Token;
+            this._state = "starting";
+
+            this.Completion = CommitLoop();
+        }
+
+        public object GetStats()
+        {
+            return new
+            {
+                State = this._state,
+                TotalCommits = this._totalCommits,
+                DelayedCommits = this._commitDelays,
+                QueueFullCommits = this._commitNows
+            };
+        }
+
+        public void Complete()
+        {
+            lock (this._taskLock)
+            {
+                this._complete = true;
+            }
+
+            this._cancellation.Cancel();
+        }
+
+        public Task Completion { get; }
+
+        /// <summary>
+        /// Returns true if the commit was queued, false if it was already queued or the poller is Complete
+        /// </summary>
+        public bool CommitWithin(TimeSpan delay)
+        {
+            lock (this._taskLock)
+            {
+                if (!this._complete)
+                {
+                    return this._commitDelay.TrySetResult(delay);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if the commit was queued, false if it was already queued or the poller is Complete
+        /// </summary>
+        public bool CommitNow()
+        {
+            lock (this._taskLock)
+            {
+                if (!this._complete)
+                {
+                    return this._commitNow.TrySetResult();
+                }
+            }
+
+            return false;
+        }
+
+        private readonly object _taskLock = new();
+        private TaskCompletionSource _commitNow = new();
+        private TaskCompletionSource<TimeSpan> _commitDelay = new();
+        private long _totalCommits;
+        private long _commitDelays;
+        private long _commitNows;
+
+        private async Task CommitLoop()
+        {
+            while (true)
+            {
+                this._state = "idle";
+
+                var delayTask = Task.Delay(-1, this._cancellationToken);
+                var result = await Task.WhenAny(
+                    delayTask,
+                    this._commitNow.Task,
+                    this._commitDelay.Task);
+
+                if (result == delayTask)
+                {
+                    // see if there's any work to be done before loop completion
+                    if (this._commitNow.Task.IsCompletedSuccessfully || this._commitDelay.Task.IsCompletedSuccessfully)
+                    {
+                        await PerformCommit();
+                    }
+
+                    break;
+                }
+                
+                if (result == this._commitNow.Task)
+                {
+                    Interlocked.Increment(ref this._commitNows);
+                    lock (this._taskLock)
+                    {
+                        this._commitNow = new();
+                    }
+
+                }
+                else if (result == this._commitDelay.Task)
+                {
+                    Interlocked.Increment(ref this._commitDelays);
+                    TimeSpan duration;
+                    lock (this._taskLock)
+                    {
+                        duration = this._commitDelay.Task.Result;
+                        this._commitDelay = new();
+                    }
+
+                    this._state = $"waiting {duration:g}";
+
+                    result = await Task.WhenAny(
+                        this._commitNow.Task,
+                        Task.Delay(duration, this._cancellationToken));
+
+                    if (result == this._commitNow.Task)
+                    {
+                        Interlocked.Increment(ref this._commitNows);
+                        lock (this._taskLock)
+                        {
+                            this._commitNow = new();
+                        }
+                    }
+                }
+
+                await PerformCommit();
+            }
+
+            this._state = "completed";
+        }
+
+        private Task PerformCommit()
+        {
+            this._state = "committing";
+            Interlocked.Increment(ref this._totalCommits);
+            return this._committer.CommitNow(default);
+        }
+    }
+}

--- a/src/Parallafka/IMessageCommitter.cs
+++ b/src/Parallafka/IMessageCommitter.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Parallafka
+{
+    internal interface IMessageCommitter
+    {
+        /// <summary>
+        /// Commits any messages that can be committed
+        /// </summary>
+        Task CommitNow(CancellationToken cancellationToken);
+    }
+}

--- a/src/Parallafka/IMessagesToCommit.cs
+++ b/src/Parallafka/IMessagesToCommit.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Parallafka.KafkaConsumer;
+
+namespace Parallafka
+{
+    internal interface IMessagesToCommit<TKey, TValue>
+    {
+        /// <summary>
+        /// Returns an enumeration of messages that are ready to be committed to kafka.
+        /// The commit queues are emptied as much as possible during this enumeration.
+        /// </summary>
+        IEnumerable<KafkaMessageWrapped<TKey, TValue>> GetMessagesToCommit();
+    }
+}

--- a/src/Parallafka/IParallafka.cs
+++ b/src/Parallafka/IParallafka.cs
@@ -8,6 +8,12 @@ namespace Parallafka
     public interface IParallafka<TKey, TValue>
     {
         /// <summary>
+        /// Returns an anonymous type instance of statistics for the parallafka running instance
+        /// </summary>
+        /// <returns></returns>
+        object GetStats();
+
+        /// <summary>
         /// Continues consuming messages until the stopToken is cancelled
         /// </summary>
         /// <param name="messageHandlerAsync">The delegate that receives the message</param>

--- a/src/Parallafka/IParallafkaConfig.cs
+++ b/src/Parallafka/IParallafkaConfig.cs
@@ -10,9 +10,9 @@ namespace Parallafka
         ILogger Logger { get; }
 
         /// <summary>
-        /// The maximum delay for committing messages to Kafka
+        /// The maximum delay for committing messages to Kafka.  Use TimeSpan.Zero to commit as quickly as possible after processing the message.
         /// </summary>
-        TimeSpan? CommitDelay { get; }
+        TimeSpan CommitDelay { get; }
 
         /// <summary>
         /// Gets the maximum queued messages.  Defaults to 1000

--- a/src/Parallafka/IParallafkaConfig.cs
+++ b/src/Parallafka/IParallafkaConfig.cs
@@ -3,10 +3,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Parallafka
 {
-    public interface IParallafkaConfig<TKey, TValue>
+    /// <summary>
+    /// Describes the configuration for <see cref="Parallafka{TKey,TValue}"/>
+    /// </summary>
+    public interface IParallafkaConfig
     {
+        /// <summary>
+        /// The maximum degree of parallelism for handling messages.  More parallelism = more throughput, but more resources
+        /// </summary>
         int MaxDegreeOfParallelism { get; }
 
+        /// <summary>
+        /// Gets the logger to use
+        /// </summary>
         ILogger Logger { get; }
 
         /// <summary>
@@ -17,7 +26,7 @@ namespace Parallafka
         /// <summary>
         /// Gets the maximum queued messages.  Defaults to 1000
         /// </summary>
-        int? MaxQueuedMessages { get; }
+        int MaxQueuedMessages { get; }
 
         // TODO: adaptive mode flag: optimize throughput by tuning thread count
 

--- a/src/Parallafka/InternalsVisibleTo.cs
+++ b/src/Parallafka/InternalsVisibleTo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Parallafka.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 

--- a/src/Parallafka/KafkaConsumer/IKafkaConsumer.cs
+++ b/src/Parallafka/KafkaConsumer/IKafkaConsumer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,9 +13,9 @@ namespace Parallafka.KafkaConsumer
     {
         /// <summary>
         /// Polls Kafka for the next record.
-        /// Returns null iff the cancellationToken is cancelled.
+        /// Returns the next record, or throws an <see cref="OperationCanceledException"/> if the cancellationToken is cancelled.
         /// </summary>
-        Task<IKafkaMessage<TKey, TValue>> PollAsync(CancellationToken cancellationToken); // TODO: What's the contract as far as nulls, op cancelled ex
+        Task<IKafkaMessage<TKey, TValue>> PollAsync(CancellationToken cancellationToken);
 
         Task CommitAsync(IKafkaMessage<TKey, TValue> message);
     }

--- a/src/Parallafka/KafkaConsumer/IKafkaMessage.cs
+++ b/src/Parallafka/KafkaConsumer/IKafkaMessage.cs
@@ -1,13 +1,26 @@
 namespace Parallafka.KafkaConsumer
 {
-    public interface IKafkaMessage<TKey, TValue>
+    /// <summary>
+    /// A kafka message with a specific Key and Value.
+    /// <seealso cref="KafkaMessage"/>
+    /// </summary>
+    /// <typeparam name="TKey">The key type</typeparam>
+    /// <typeparam name="TValue">The value type</typeparam>
+    public interface IKafkaMessage<out TKey, out TValue>
     {
+        /// <summary>
+        /// The message key
+        /// </summary>
         TKey Key { get; }
 
+        /// <summary>
+        /// The message value (may be null)
+        /// </summary>
         TValue Value { get; }
 
-        IRecordOffset Offset { get; } // TODO: not null
-
-        bool WasHandled { get; set; } // TODO: this is internal
+        /// <summary>
+        /// The kafka offset for the message
+        /// </summary>
+        IRecordOffset Offset { get; }
     }
 }

--- a/src/Parallafka/KafkaConsumer/IRecordOffset.cs
+++ b/src/Parallafka/KafkaConsumer/IRecordOffset.cs
@@ -2,10 +2,19 @@ using System;
 
 namespace Parallafka.KafkaConsumer
 {
+    /// <summary>
+    /// The description of the message partition and offset
+    /// </summary>
     public interface IRecordOffset : IEquatable<IRecordOffset>
     {
+        /// <summary>
+        /// The partition for the record
+        /// </summary>
         int Partition { get; }
 
+        /// <summary>
+        /// The offset of the record
+        /// </summary>
         long Offset { get; }
     }
 }

--- a/src/Parallafka/KafkaConsumer/KafkaMessage.cs
+++ b/src/Parallafka/KafkaConsumer/KafkaMessage.cs
@@ -1,22 +1,39 @@
-using System;
-
-namespace Parallafka.KafkaConsumer
+﻿namespace Parallafka.KafkaConsumer
 {
-    public class KafkaMessage<TKey, TValue> : IKafkaMessage<TKey, TValue>
+    /// <summary>
+    /// Helper class to create a KafkaMessage
+    /// </summary>
+    public static class KafkaMessage
     {
-        public KafkaMessage(TKey key, TValue value, IRecordOffset offset = null)
+        /// <summary>
+        /// Creates a new instance of a <see cref="IKafkaMessage{TKey,TValue}"/> for a give key, value and offset
+        /// </summary>
+        /// <typeparam name="TKey">The key type</typeparam>
+        /// <typeparam name="TValue">The value type</typeparam>
+        /// <param name="key">The message key</param>
+        /// <param name="value">The message value (may be null)</param>
+        /// <param name="offset">The message offset</param>
+        /// <returns></returns>
+        public static IKafkaMessage<TKey, TValue> Create<TKey, TValue>(
+            TKey key, 
+            TValue value,
+            IRecordOffset offset)
         {
-            this.Key = key;
-            this.Value = value;
-            this.Offset = offset;
+            return new KafkaMessageImpl<TKey, TValue>(key, value, offset);
         }
 
-        public TKey Key { get; }
+        private class KafkaMessageImpl<TKey, TValue> : IKafkaMessage<TKey, TValue>
+        {
+            public KafkaMessageImpl(TKey key, TValue value, IRecordOffset offset)
+            {
+                this.Key = key;
+                this.Value = value;
+                this.Offset = offset;
+            }
 
-        public TValue Value { get; }
-
-        public IRecordOffset Offset { get; }
-
-        public bool WasHandled { get; set; }
+            public TKey Key { get; }
+            public TValue Value { get; }
+            public IRecordOffset Offset { get; }
+        }
     }
 }

--- a/src/Parallafka/KafkaConsumer/KafkaMessageWrapped.cs
+++ b/src/Parallafka/KafkaConsumer/KafkaMessageWrapped.cs
@@ -1,0 +1,50 @@
+namespace Parallafka.KafkaConsumer
+{
+    /// <summary>
+    /// The message from kafka - a key, value and offset
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    /// <typeparam name="TValue"></typeparam>
+    internal class KafkaMessageWrapped<TKey, TValue>
+    {
+        /// <summary>
+        /// Creates a new instance of a <see cref="KafkaMessageWrapped{TKey, TValue}"/> for a specific message
+        /// </summary>
+        public KafkaMessageWrapped(IKafkaMessage<TKey, TValue> message)
+        {
+            this.Message = message;
+        }
+
+        public IKafkaMessage<TKey, TValue> Message { get; }
+
+        /// <summary>
+        /// The Key for the message
+        /// </summary>
+        public TKey Key => this.Message.Key;
+
+        /// <summary>
+        /// The Value for the message (may be null)
+        /// </summary>
+        public TValue Value => this.Message.Value;
+
+        /// <summary>
+        /// The record off for the message
+        /// </summary>
+        public IRecordOffset Offset => this.Message.Offset;
+
+        public bool ReadyToCommit { get; private set; }
+
+        public void SetIsReadyToCommit()
+        {
+            this.ReadyToCommit = true;
+        }
+    }
+
+    internal static class KafkaMessageWrappedExtensions
+    {
+        public static KafkaMessageWrapped<TKey, TValue> Wrapped<TKey, TValue>(this IKafkaMessage<TKey, TValue> message)
+        {
+            return new KafkaMessageWrapped<TKey, TValue>(message);
+        }
+    }
+}

--- a/src/Parallafka/KafkaConsumer/RecordOffset.cs
+++ b/src/Parallafka/KafkaConsumer/RecordOffset.cs
@@ -2,23 +2,35 @@ using System;
 
 namespace Parallafka.KafkaConsumer
 {
+    /// <summary>
+    /// Describes the partition/offset of the message
+    /// </summary>
     public class RecordOffset : IRecordOffset
     {
+        /// <summary>
+        /// Creates an instance of <see cref="RecordOffset"/> with the specified partition and offset
+        /// </summary>
+        /// <param name="partition">The message partition</param>
+        /// <param name="offset">The message offset</param>
         public RecordOffset(int partition, long offset)
         {
             this.Partition = partition;
             this.Offset = offset;
         }
         
+        /// <inheritdoc />
         public int Partition { get; }
 
+        /// <inheritdoc />
         public long Offset { get; }
 
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             return this.Equals(obj as IRecordOffset);
         }
 
+        /// <inheritdoc />
         public bool Equals(IRecordOffset other)
         {
             if (object.ReferenceEquals(this, null))
@@ -32,11 +44,13 @@ namespace Parallafka.KafkaConsumer
             return other.Offset == this.Offset && other.Partition == this.Partition;
         }
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return HashCode.Combine(this.Partition, this.Offset);
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"P:{this.Partition} O:{this.Offset}";

--- a/src/Parallafka/MessageCommitter.cs
+++ b/src/Parallafka/MessageCommitter.cs
@@ -31,7 +31,6 @@ namespace Parallafka
         {
             return new
             {
-                this._commitBlock.InputCount,
                 MessageCommitLoopInProgress = _messageCommitLoopInProgress,
                 MessagesCommitted = this._messagesCommitted,
                 MessagesCommitErrors = this._messagesCommitErrors,

--- a/src/Parallafka/MessageCommitter.cs
+++ b/src/Parallafka/MessageCommitter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 using Microsoft.Extensions.Logging;
 using Parallafka.KafkaConsumer;
 
@@ -12,105 +11,49 @@ namespace Parallafka
         private readonly IKafkaConsumer<TKey, TValue> _consumer;
         private readonly CommitState<TKey, TValue> _commitState;
         private readonly ILogger _logger;
-        private readonly CancellationToken _stopToken;
-        private readonly CancellationTokenSource _stopTimer;
-        private readonly ActionBlock<int> _commitBlock;
 
         public MessageCommitter(
             IKafkaConsumer<TKey, TValue> consumer,
             CommitState<TKey, TValue> commitState,
-            ILogger logger,
-            TimeSpan timerDelay,
-            CancellationToken stopToken)
+            ILogger logger)
         {
-            this._commitBlock = new ActionBlock<int>(_ => GetAndCommitAnyMessages(),
-                new ExecutionDataflowBlockOptions
-                {
-                    MaxDegreeOfParallelism = 1,
-                    BoundedCapacity = 2
-                });
-
             this._consumer = consumer;
             this._commitState = commitState;
             this._logger = logger;
-            this._stopToken = stopToken;
-            this._stopTimer = new();
-            this.Completion =
-                Task.WhenAll(
-                    this._commitBlock.Completion,
-                    Task.Run(() => this.CommitOnTimer(timerDelay)));
         }
-
-        /// <summary>
-        /// Indicates that the message committer should complete all possible commits.
-        /// Await <see cref="Completion"/> to know when the committer is completed.
-        /// </summary>
-        public void Complete()
-        {
-            this._stopTimer.Cancel();
-            this._commitBlock.Post(1);
-            this._commitBlock.Complete();
-
-            Parallafka<TKey, TValue>.WriteLine("MC Complete() called");
-        }
-
-        /// <summary>
-        /// A task that when completed indicates the committer is finished processing
-        /// </summary>
-        public Task Completion { get; }
 
         /// <summary>
         /// Commits any messages that can be committed
         /// </summary>
-        public Task CommitNow()
+        public Task CommitNow(CancellationToken cancellationToken)
         {
-            this._commitBlock.Post(1);
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Commits any messages on a timer delay
-        /// </summary>
-        /// <param name="delay"></param>
-        /// <returns></returns>
-        private async Task CommitOnTimer(TimeSpan delay)
-        {
-            while (!this._stopTimer.IsCancellationRequested)
-            {
-                try
-                {
-                    await Task.Delay(delay, this._stopTimer.Token);
-                }
-                catch (OperationCanceledException)
-                {
-                }
-
-                await CommitNow();
-            }
+            return this.GetAndCommitAnyMessages(cancellationToken);
         }
 
         /// <summary>
         /// Gets any possible messages to commit and commits them
         /// </summary>
         /// <returns></returns>
-        private async Task GetAndCommitAnyMessages()
+        private async Task GetAndCommitAnyMessages(CancellationToken cancellationToken)
         {
             Parallafka<TKey, TValue>.WriteLine("GetAndCommitAnyMessages start");
             foreach (var message in this._commitState.GetMessagesToCommit())
             {
-                await CommitMessage(message);
+                await CommitMessage(message, cancellationToken);
             }
 
             Parallafka<TKey, TValue>.WriteLine("GetAndCommitAnyMessages finish");
         }
 
-        private async Task CommitMessage(IKafkaMessage<TKey, TValue> messageToCommit)
+        private async Task CommitMessage(IKafkaMessage<TKey, TValue> messageToCommit, CancellationToken cancellationToken)
         {
-            while (!this._stopToken.IsCancellationRequested)
+            for(;;)
             {
                 try
                 {
                     Parallafka<TKey, TValue>.WriteLine($"MsgCommitter: committing {messageToCommit.Offset}");
+
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     // TODO: inject CancelToken for hard-stop strategy?
                     await this._consumer.CommitAsync(messageToCommit);
@@ -120,7 +63,7 @@ namespace Parallafka
                 catch (Exception e)
                 {
                     this._logger.LogError(e, "Error committing offsets");
-                    await Task.Delay(99);
+                    await Task.Delay(99, cancellationToken);
                 }
             }
         }

--- a/src/Parallafka/MessageFinishedRouter.cs
+++ b/src/Parallafka/MessageFinishedRouter.cs
@@ -12,7 +12,10 @@ namespace Parallafka
         public MessageFinishedRouter(MessagesByKey<TKey, TValue> messageByKey)
         {
             this._messageByKey = messageByKey;
-            this._messagesToHandle = new(new DataflowBlockOptions { BoundedCapacity = 1 });
+            this._messagesToHandle = new(new DataflowBlockOptions
+            {
+                BoundedCapacity = 1
+            });
         }
 
         public ISourceBlock<IKafkaMessage<TKey, TValue>> MessagesToHandle => this._messagesToHandle;

--- a/src/Parallafka/MessageFinishedRouter.cs
+++ b/src/Parallafka/MessageFinishedRouter.cs
@@ -8,7 +8,7 @@ namespace Parallafka
     internal class MessageFinishedRouter<TKey, TValue>
     {
         private readonly MessagesByKey<TKey, TValue> _messageByKey;
-        private readonly BufferBlock<IKafkaMessage<TKey, TValue>> _messagesToHandle;
+        private readonly BufferBlock<KafkaMessageWrapped<TKey, TValue>> _messagesToHandle;
 
         private long _messagesHandled;
         private long _messagesSkipped;
@@ -24,7 +24,7 @@ namespace Parallafka
             });
         }
 
-        public ISourceBlock<IKafkaMessage<TKey, TValue>> MessagesToHandle => this._messagesToHandle;
+        public ISourceBlock<KafkaMessageWrapped<TKey, TValue>> MessagesToHandle => this._messagesToHandle;
 
         public Task Completion => this._messageByKey.Completion;
 
@@ -45,7 +45,7 @@ namespace Parallafka
             this._messageByKey.Complete();
         }
 
-        public async Task MessageHandlerFinished(IKafkaMessage<TKey, TValue> message)
+        public async Task MessageHandlerFinished(KafkaMessageWrapped<TKey, TValue> message)
         {
             Interlocked.Increment(ref this._messagesHandled);
             // If there are any messages with the same key queued, make the next one available for handling.

--- a/src/Parallafka/MessageFinishedRouter.cs
+++ b/src/Parallafka/MessageFinishedRouter.cs
@@ -11,7 +11,6 @@ namespace Parallafka
         private readonly BufferBlock<KafkaMessageWrapped<TKey, TValue>> _messagesToHandle;
 
         private long _messagesHandled;
-        private long _messagesSkipped;
         private long _messagesSent;
         private long _messagesNotSent;
 
@@ -35,8 +34,7 @@ namespace Parallafka
                 InputCount = this._messagesToHandle.Count,
                 MessagesHandled = this._messagesHandled,
                 MessagesSent = this._messagesSent,
-                MessagesNotSent = this._messagesNotSent,
-                MessagesSkipped = this._messagesSkipped
+                MessagesNotSent = this._messagesNotSent
             };
         }
 
@@ -61,10 +59,6 @@ namespace Parallafka
                     Interlocked.Increment(ref this._messagesNotSent);
                     Parallafka<TKey, TValue>.WriteLine($"MFR: {newMessage.Key} {newMessage.Offset} SendAsync failed!");
                 }
-            }
-            else
-            {
-                Interlocked.Increment(ref this._messagesSkipped);
             }
         }
 

--- a/src/Parallafka/MessageRouter.cs
+++ b/src/Parallafka/MessageRouter.cs
@@ -11,8 +11,11 @@ namespace Parallafka
         private readonly MessagesByKey<TKey, TValue> _messageByKey;
         private readonly CancellationToken _stopToken;
 
-
         private readonly BufferBlock<IKafkaMessage<TKey, TValue>> _messagesToHandle;
+        private long _messagesRouted;
+        private long _messagesSkipped;
+        private long _messagesHandled;
+        private long _messagesNotHandled;
 
         public MessageRouter(
             CommitState<TKey, TValue> commitState,
@@ -28,20 +31,40 @@ namespace Parallafka
             });
         }
 
+        public object GetStats()
+        {
+            return new
+            {
+                MessagesRouted = this._messagesRouted,
+                MessagesHandled = this._messagesHandled,
+                MessagesNotHandled = this._messagesNotHandled,
+                MessagesSkipped = this._messagesSkipped,
+                IncomingQueueSize = this._messagesToHandle.Count
+            };
+        }
+
         public ISourceBlock<IKafkaMessage<TKey, TValue>> MessagesToHandle => this._messagesToHandle;
 
         public async Task RouteMessage(IKafkaMessage<TKey, TValue> message)
         {
+            Interlocked.Increment(ref _messagesRouted);
+
             await this._commitState.EnqueueMessageAsync(message);
 
             if (!this._messageByKey.TryAddMessageToHandle(message))
             {
+                Interlocked.Increment(ref _messagesSkipped);
                 return;
             }
 
             if (!await this._messagesToHandle.SendAsync(message, this._stopToken))
             {
+                Interlocked.Increment(ref _messagesNotHandled);
                 Parallafka<TKey, TValue>.WriteLine($"MR: {message.Key} {message.Offset} SendAsync failed!");
+            }
+            else
+            {
+                Interlocked.Increment(ref _messagesHandled);
             }
         }
     }

--- a/src/Parallafka/MessagesByKey.cs
+++ b/src/Parallafka/MessagesByKey.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Parallafka.KafkaConsumer;
 
@@ -23,6 +24,17 @@ namespace Parallafka
             this._messagesToHandleForKey = new();
             this._completedSource = new();
             this.Completion = this._completedSource.Task;
+        }
+
+        public object GetStats()
+        {
+            lock (this._messagesToHandleForKey)
+            {
+                return new
+                {
+                    MessageCountsByKey = this._messagesToHandleForKey.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.Count ?? 0)
+                };
+            }
         }
 
         /// <summary>

--- a/src/Parallafka/MessagesByKey.cs
+++ b/src/Parallafka/MessagesByKey.cs
@@ -55,7 +55,7 @@ namespace Parallafka
         {
             lock (this._messagesToHandleForKey)
             {
-                if (!this._messagesToHandleForKey.TryGetValue(message.Key, out var messagesQueuedForKey))
+                if (!this._messagesToHandleForKey.TryGetValue(message.Key, out Queue<IKafkaMessage<TKey, TValue>> messagesQueuedForKey))
                 {
                     // shouldn't happen
                     nextMessage = null;

--- a/src/Parallafka/MessagesByKey.cs
+++ b/src/Parallafka/MessagesByKey.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Parallafka.KafkaConsumer;
 
@@ -15,12 +16,18 @@ namespace Parallafka
     /// </summary>
     internal class MessagesByKey<TKey, TValue>
     {
-        private readonly Dictionary<TKey, Queue<IKafkaMessage<TKey, TValue>>> _messagesToHandleForKey;
+        private readonly CancellationToken _cancellationToken;
+        private readonly Dictionary<TKey, Queue<KafkaMessageWrapped<TKey, TValue>>> _messagesToHandleForKey;
         private readonly TaskCompletionSource _completedSource;
         private bool _completed;
 
-        public MessagesByKey()
+        /// <summary>
+        /// Creates a new instance of <see cref="MessagesByKey{TKey,TValue}"/>
+        /// </summary>
+        /// <param name="cancellationToken">When the token is cancelled, no more messages will be processed</param>
+        public MessagesByKey(CancellationToken cancellationToken)
         {
+            this._cancellationToken = cancellationToken;
             this._messagesToHandleForKey = new();
             this._completedSource = new();
             this.Completion = this._completedSource.Task;
@@ -45,6 +52,11 @@ namespace Parallafka
             this._completed = true;
             lock (this._messagesToHandleForKey)
             {
+                if (this._cancellationToken.IsCancellationRequested)
+                {
+                    this._messagesToHandleForKey.Clear();
+                }
+
                 if (this._messagesToHandleForKey.Count == 0)
                 {
                     this._completedSource.TrySetResult();
@@ -55,7 +67,7 @@ namespace Parallafka
         /// <summary>
         /// A task that is completed when the instance is finished processing
         /// </summary>
-        public Task Completion { get; private set; }
+        public Task Completion { get; }
         
         /// <summary>
         /// Given a message, attempts to return another message to handle for the same message key
@@ -63,11 +75,24 @@ namespace Parallafka
         /// <param name="message">The message that was handled</param>
         /// <param name="nextMessage">The next message that should be handled</param>
         /// <returns>True if a nextMessage was found</returns>
-        public bool TryGetNextMessageToHandle(IKafkaMessage<TKey, TValue> message, [NotNullWhen(true)] out IKafkaMessage<TKey, TValue> nextMessage)
+        public bool TryGetNextMessageToHandle(KafkaMessageWrapped<TKey, TValue> message, [NotNullWhen(true)] out KafkaMessageWrapped<TKey, TValue> nextMessage)
         {
             lock (this._messagesToHandleForKey)
             {
-                if (!this._messagesToHandleForKey.TryGetValue(message.Key, out Queue<IKafkaMessage<TKey, TValue>> messagesQueuedForKey))
+                if (this._cancellationToken.IsCancellationRequested)
+                {
+                    this._messagesToHandleForKey.Clear();
+
+                    if (this._completed)
+                    {
+                        this._completedSource.TrySetResult();
+                    }
+
+                    nextMessage = null;
+                    return false;
+                }
+
+                if (!this._messagesToHandleForKey.TryGetValue(message.Key, out Queue<KafkaMessageWrapped<TKey, TValue>> messagesQueuedForKey))
                 {
                     // shouldn't happen
                     nextMessage = null;
@@ -104,17 +129,22 @@ namespace Parallafka
         /// </summary>
         /// <param name="message"></param>
         /// <returns></returns>
-        public bool TryAddMessageToHandle(IKafkaMessage<TKey, TValue> message)
+        public bool TryAddMessageToHandle(KafkaMessageWrapped<TKey, TValue> message)
         {
             lock (this._messagesToHandleForKey)
             {
+                if (this._cancellationToken.IsCancellationRequested)
+                {
+                    return false;
+                }
+
                 var aMessageWithThisKeyIsCurrentlyBeingHandled = this._messagesToHandleForKey.TryGetValue(message.Key, out var messagesToHandleForKey);
 
                 if (aMessageWithThisKeyIsCurrentlyBeingHandled)
                 {
                     if (messagesToHandleForKey == null)
                     {
-                        messagesToHandleForKey = new Queue<IKafkaMessage<TKey, TValue>>();
+                        messagesToHandleForKey = new Queue<KafkaMessageWrapped<TKey, TValue>>();
                         this._messagesToHandleForKey[message.Key] = messagesToHandleForKey;
                     }
 

--- a/src/Parallafka/Parallafka.cs
+++ b/src/Parallafka/Parallafka.cs
@@ -155,6 +155,9 @@ namespace Parallafka
                             }
                         }
                     }
+                    catch (OperationCanceledException)
+                    {
+                    }
                     catch (Exception e)
                     {
                         this._logger.LogError(e, "Error in Kafka poller thread");

--- a/src/Parallafka/Parallafka.cs
+++ b/src/Parallafka/Parallafka.cs
@@ -32,7 +32,7 @@ namespace Parallafka
         {
             var maxQueuedMessages = this._config.MaxQueuedMessages ?? 1000;
             // Are there any deadlocks or performance issues with these caps in general?
-            var localStop = new CancellationTokenSource();
+            using var localStop = new CancellationTokenSource();
             var commitState = new CommitState<TKey, TValue>(maxQueuedMessages, localStop.Token);
             var messagesByKey = new MessagesByKey<TKey, TValue>();
 

--- a/src/Parallafka/Parallafka.cs
+++ b/src/Parallafka/Parallafka.cs
@@ -55,7 +55,7 @@ namespace Parallafka
             var handlerTarget = new ActionBlock<IKafkaMessage<TKey, TValue>>(handler.HandleMessage,
                 new ExecutionDataflowBlockOptions
                 {
-                    BoundedCapacity = maxQueuedMessages,
+                    BoundedCapacity = Math.Max(maxQueuedMessages, this._config.MaxDegreeOfParallelism),
                     MaxDegreeOfParallelism = this._config.MaxDegreeOfParallelism
                 });
 

--- a/src/Parallafka/Parallafka.cs
+++ b/src/Parallafka/Parallafka.cs
@@ -124,53 +124,53 @@ namespace Parallafka
         
         private async Task KafkaPollerThread(ITargetBlock<IKafkaMessage<TKey, TValue>> routingTarget, CancellationToken stopToken)
         {
+            int? delay = null;
+
             try
             {
-                while (!stopToken.IsCancellationRequested)
+                for(;;)
                 {
                     // TODO: Error handling
                     try
                     {
+                        if (delay.HasValue)
+                        {
+                            await Task.Delay(delay.Value, stopToken);
+                            delay = null;
+                        }
+
                         IKafkaMessage<TKey, TValue> message = await this._consumer.PollAsync(stopToken);
                         if (message == null)
                         {
-                            if (!stopToken.IsCancellationRequested)
-                            {
-                                this._logger.LogWarning(
-                                    "Polled a null message while not shutting down: breach of IKafkaConsumer contract");
-                                await Task.Delay(50);
-                            }
+                            stopToken.ThrowIfCancellationRequested();
+                            this._logger.LogWarning("Polled a null message while not shutting down: breach of IKafkaConsumer contract");
+                            delay = 50;
                         }
                         else
                         {
-                            try
-                            {
-                                WriteLine($"Poller: Sending {message.Key} {message.Offset}");
-                                await routingTarget.SendAsync(message, stopToken);
-                                WriteLine($"Poller: Sent {message.Key} {message.Offset}");
-                            }
-                            catch (OperationCanceledException)
-                            {
-                                break;
-                            }
+                            WriteLine($"Poller: Sending {message.Key} {message.Offset}");
+                            await routingTarget.SendAsync(message, stopToken);
+                            WriteLine($"Poller: Sent {message.Key} {message.Offset}");
                         }
                     }
                     catch (OperationCanceledException)
                     {
+                        throw;
                     }
                     catch (Exception e)
                     {
                         this._logger.LogError(e, "Error in Kafka poller thread");
-                        await Task.Delay(333);
+                        delay = 333
                     }
                 }
+            }
+            catch (OperationCanceledException)
+            {
             }
             catch (Exception e)
             {
                 this._logger.LogCritical(e, "Fatal error in Kafka poller thread");
             }
         }
-
-
     }
 }

--- a/src/Parallafka/Parallafka.cs
+++ b/src/Parallafka/Parallafka.cs
@@ -160,7 +160,7 @@ namespace Parallafka
                     catch (Exception e)
                     {
                         this._logger.LogError(e, "Error in Kafka poller thread");
-                        delay = 333
+                        delay = 333;
                     }
                 }
             }

--- a/src/Parallafka/ParallafkaConfig.cs
+++ b/src/Parallafka/ParallafkaConfig.cs
@@ -6,6 +6,7 @@ namespace Parallafka
     public class ParallafkaConfig<TKey, TValue> : IParallafkaConfig<TKey, TValue>
     {
         /// <inheritdoc />
+        /// <remarks>Defaults to 3</remarks>
         public int MaxDegreeOfParallelism { get; set; } = 3;
 
         /// <inheritdoc />
@@ -14,7 +15,8 @@ namespace Parallafka
                 .CreateLogger<IParallafka<TKey, TValue>>();
 
         /// <inheritdoc />
-        public TimeSpan? CommitDelay { get; set; } = null;
+        /// <remarks>Defaults to 5 seconds</remarks>
+        public TimeSpan CommitDelay { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <inheritdoc />
         public int? MaxQueuedMessages { get; set; } = null;

--- a/src/Parallafka/ParallafkaConfig.cs
+++ b/src/Parallafka/ParallafkaConfig.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Parallafka
 {
-    public class ParallafkaConfig<TKey, TValue> : IParallafkaConfig<TKey, TValue>
+    public class ParallafkaConfig<TKey, TValue> : IParallafkaConfig
     {
         /// <inheritdoc />
         /// <remarks>Defaults to 3</remarks>
@@ -19,6 +19,6 @@ namespace Parallafka
         public TimeSpan CommitDelay { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <inheritdoc />
-        public int? MaxQueuedMessages { get; set; } = null;
+        public int MaxQueuedMessages { get; set; } = 1_000;
     }
 }

--- a/tests/Parallafka.Tests/CommitPollerTests.cs
+++ b/tests/Parallafka.Tests/CommitPollerTests.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Parallafka.Tests
+{
+    public class CommitPollerTests
+    {
+        private readonly ITestOutputHelper _console;
+        private readonly Mock<IMessageCommitter> _committer;
+        private readonly CommitPoller _poller;
+
+        [Fact]
+        public async Task CommitNowAfterDelay()
+        {
+            // when
+            Assert.True(this._poller.CommitWithin(TimeSpan.FromSeconds(1)));
+            Assert.True(this._poller.CommitNow());
+            this._poller.Complete();
+            await this._poller.Completion;
+
+            // then
+            this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task MultipleCommitNowIgnoredDuringLongCommit()
+        {
+            // when
+            this._committer.Setup(m => m.CommitNow(It.IsAny<CancellationToken>()))
+                .Returns(() => Task.Delay(1000));
+                
+            Assert.True(this._poller.CommitNow());
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            Assert.True(this._poller.CommitNow());
+
+            // the following CommitNows should be ignored
+            Assert.False(this._poller.CommitNow());
+            Assert.False(this._poller.CommitNow());
+            Assert.False(this._poller.CommitNow());
+            Assert.False(this._poller.CommitNow());
+            Assert.False(this._poller.CommitNow());
+            this._poller.Complete();
+            await this._poller.Completion;
+
+            // then
+            this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task CommitNowCallsCommit()
+        {
+            // when
+            Assert.True(this._poller.CommitNow());
+            this._poller.Complete();
+            await this._poller.Completion;
+
+            // then
+            this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Once);
+        }
+        
+        [Fact]
+        public async Task CommitNowBeforeDelayBothCallCommit()
+        {
+            // when
+            Assert.True(this._poller.CommitNow());
+            Assert.True(this._poller.CommitWithin(TimeSpan.FromSeconds(1)));
+            this._poller.Complete();
+            await this._poller.Completion;
+
+            // then
+            this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task CommitWithinWorks()
+        {
+            // when
+            Assert.True(this._poller.CommitWithin(TimeSpan.FromMilliseconds(100)));
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            // then
+            this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Once);
+
+            this._poller.Complete();
+            await this._poller.Completion;
+        }
+
+
+        [Fact]
+        public async Task CommitWithinWithLongDelayIgnoresDelay()
+        {
+            // when
+            var sw = Stopwatch.StartNew();
+            Assert.True(this._poller.CommitWithin(TimeSpan.FromSeconds(100)));
+            this._poller.Complete();
+            await this._poller.Completion;
+
+            // then
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(1));
+            this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CommitNowIgnoredAfterCompletion()
+        {
+            // when
+            this._poller.Complete();
+            await this._poller.Completion;
+
+            Assert.False(this._poller.CommitNow());
+
+            // then
+            this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Never);
+        }
+        
+        [Fact]
+        public async Task CommitWithinIgnoredAfterCompletion()
+        {
+            // when
+            this._poller.Complete();
+            await this._poller.Completion;
+
+            Assert.False(this._poller.CommitWithin(TimeSpan.FromSeconds(1)));
+
+            // then
+            this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        public CommitPollerTests(ITestOutputHelper console)
+        {
+            this._console = console;
+            this._committer = new Mock<IMessageCommitter>();
+            this._poller = new CommitPoller(this._committer.Object);
+        }
+    }
+}

--- a/tests/Parallafka.Tests/CommitPollerTests.cs
+++ b/tests/Parallafka.Tests/CommitPollerTests.cs
@@ -125,7 +125,8 @@ namespace Parallafka.Tests
             this._poller.Complete();
             await this._poller.Completion;
 
-            Assert.False(this._poller.CommitWithin(TimeSpan.FromSeconds(1)));
+            Assert.False(this._poller.CommitWithin(TimeSpan.FromSeconds(0.5)));
+            await Task.Delay(TimeSpan.FromSeconds(1));
 
             // then
             this._committer.Verify(m => m.CommitNow(It.IsAny<CancellationToken>()), Times.Never);

--- a/tests/Parallafka.Tests/CommitStateTests.cs
+++ b/tests/Parallafka.Tests/CommitStateTests.cs
@@ -13,7 +13,7 @@ namespace Parallafka.Tests
         public async Task EnqueuesOnlyUpToMax()
         {
             //  given
-            var stop = new CancellationTokenSource();
+            using var stop = new CancellationTokenSource();
             var cs = new CommitState<string, string>(5, stop.Token);
             var messages = Enumerable.Range(0, 6)
                 .Select(i => new KafkaMessage<string, string>("key", "value", new RecordOffset(0, i)))
@@ -25,7 +25,7 @@ namespace Parallafka.Tests
             }
 
             var message6 = messages.Last();
-            var waitToken = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            using var waitToken = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 
             // when/then
             var enqueueTask = cs.EnqueueMessageAsync(message6);

--- a/tests/Parallafka.Tests/Commits/CommitTestsBase.cs
+++ b/tests/Parallafka.Tests/Commits/CommitTestsBase.cs
@@ -35,7 +35,7 @@ namespace Parallafka.Tests.Commits
                 var consumed = new ConcurrentQueue<IKafkaMessage<string, string>>();
                 var firstPartitionMsgsConsumed = new ConcurrentQueue<IKafkaMessage<string, string>>();
                 TaskCompletionSource hangEarlyMsgTcs = new();
-                CancellationTokenSource stopConsuming = new CancellationTokenSource();
+                using CancellationTokenSource stopConsuming = new CancellationTokenSource();
                 Task consumeTask = parallafka.ConsumeAsync(async msg =>
                 {
                     await Task.Delay(StaticRandom.Use(r => r.Next(25)));

--- a/tests/Parallafka.Tests/Contracts/ConsumerPollTestsBase.cs
+++ b/tests/Parallafka.Tests/Contracts/ConsumerPollTestsBase.cs
@@ -28,7 +28,7 @@ namespace Parallafka.Tests.Contracts
         public virtual async Task RawConsumerHangsAtPartitionEndsTillNewMessageOrCancellationAsync()
         {
             bool receivedNullMsg = false;
-            var cts = new CancellationTokenSource(60_000);
+            using var cts = new CancellationTokenSource(60_000);
             await using IKafkaConsumer<string, string> consumer = await this.Topic.GetConsumerAsync("rawConsumer");
             await this.AssertConsumerHangsAtPartitionEndsTillNewMessageAsync(consumeTopicAsync: async (handleAsync, ct) =>
             {

--- a/tests/Parallafka.Tests/Contracts/ConsumerPollTestsBase.cs
+++ b/tests/Parallafka.Tests/Contracts/ConsumerPollTestsBase.cs
@@ -34,13 +34,17 @@ namespace Parallafka.Tests.Contracts
             {
                 while (true)
                 {
-                    IKafkaMessage<string, string> message = await consumer.PollAsync(cts.Token);
-                    if (message == null)
+                    try
+                    {
+                        IKafkaMessage<string, string> message = await consumer.PollAsync(cts.Token);
+
+                        await handleAsync(message);
+                    }
+                    catch (OperationCanceledException)
                     {
                         receivedNullMsg = true;
                         break;
                     }
-                    await handleAsync(message);
                 }
             }, () =>
             {

--- a/tests/Parallafka.Tests/DataflowPostTests.cs
+++ b/tests/Parallafka.Tests/DataflowPostTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Xunit;
+
+namespace Parallafka.Tests
+{
+    public class DataflowPostTests
+    {
+        /// <summary>
+        /// Verifies that Post returns false when the ActionBlock is busy with all the tasks
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task VerifyDataflowPostWorksAsExpected()
+        {
+            // given
+            var got = 0;
+            var ab = new ActionBlock<int>(async i =>
+            {
+                Interlocked.Increment(ref got);
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                Interlocked.Decrement(ref got);
+
+            }, new ExecutionDataflowBlockOptions
+            {
+                BoundedCapacity = 1,
+                MaxDegreeOfParallelism = 1
+            });
+
+            try
+            {
+                Assert.True(ab.Post(1));
+                while (got != 1)
+                {
+                    await Task.Yield();
+                }
+
+                // when the action block is busy with the single current task, Post will return false
+                Assert.False(ab.Post(1));
+                while (got == 1)
+                {
+                    await Task.Delay(100);
+                }
+
+                // and when the action block finishes the current task, Post will return true again
+                Assert.True(ab.Post(1));
+
+            }
+            finally
+            {
+                // cleanup
+                ab.Complete();
+                await ab.Completion;
+            }
+        }
+    }
+}

--- a/tests/Parallafka.Tests/DataflowPostTests.cs
+++ b/tests/Parallafka.Tests/DataflowPostTests.cs
@@ -1,13 +1,22 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Parallafka.Tests
 {
     public class DataflowPostTests
     {
+        private readonly ITestOutputHelper _console;
+
+        public DataflowPostTests(ITestOutputHelper console)
+        {
+            _console = console;
+        }
+
         /// <summary>
         /// Verifies that Post returns false when the ActionBlock is busy with all the tasks
         /// </summary>
@@ -16,12 +25,15 @@ namespace Parallafka.Tests
         public async Task VerifyDataflowPostWorksAsExpected()
         {
             // given
+            var sw = Stopwatch.StartNew();
             var got = 0;
             var ab = new ActionBlock<int>(async i =>
             {
+                this._console.WriteLine($"{sw.Elapsed:g} Block started {i}");
                 Interlocked.Increment(ref got);
                 await Task.Delay(TimeSpan.FromSeconds(1));
                 Interlocked.Decrement(ref got);
+                this._console.WriteLine($"{sw.Elapsed:g} Block finished {i}");
 
             }, new ExecutionDataflowBlockOptions
             {
@@ -39,17 +51,35 @@ namespace Parallafka.Tests
 
                 // when the action block is busy with the single current task, Post will return false
                 Assert.False(ab.Post(1));
-                while (got == 1)
+                while (got == 1 && ab.InputCount > 0)
                 {
                     await Task.Delay(100);
                 }
 
-                // and when the action block finishes the current task, Post will return true again
-                Assert.True(ab.Post(1));
+                await Task.Delay(1000);
 
+                this._console.WriteLine($"{sw.Elapsed:g} Sending 2");
+
+                // and when the action block finishes the current task, Post will return true again
+                var c = 0;
+                for (;;)
+                {
+                    c++;
+                    var b = await ab.SendAsync(2);
+                    if (b)
+                    {
+                        break;
+                    }
+                }
+
+                this._console.WriteLine($"{sw.Elapsed:g} Sent 2 in {c} tries");
+
+                // Assert.True(b);
             }
             finally
             {
+                await Task.Delay(1000);
+
                 // cleanup
                 ab.Complete();
                 await ab.Completion;

--- a/tests/Parallafka.Tests/Helpers/FakeTestKafkaTopic.cs
+++ b/tests/Parallafka.Tests/Helpers/FakeTestKafkaTopic.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
@@ -41,7 +38,7 @@ namespace Parallafka.Tests.Helpers
                 var partition = ComputePartition(message.Key);
                 var offset = Interlocked.Increment(ref this._partitionOffsets[partition]) - 1;
 
-                var newMessage = new KafkaMessage<string, string>(
+                var newMessage = KafkaMessage.Create(
                     key: message.Key,
                     value: message.Value,
                     offset: new RecordOffset(partition, offset));

--- a/tests/Parallafka.Tests/Helpers/FakeTestKafkaTopic.cs
+++ b/tests/Parallafka.Tests/Helpers/FakeTestKafkaTopic.cs
@@ -66,16 +66,9 @@ namespace Parallafka.Tests.Helpers
                 return ValueTask.CompletedTask;
             }
 
-            public async Task<IKafkaMessage<string, string>> PollAsync(CancellationToken cancellationToken)
+            public Task<IKafkaMessage<string, string>> PollAsync(CancellationToken cancellationToken)
             {
-                try
-                {
-                    return await this._messages.ReceiveAsync(cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    return null;
-                }
+                return this._messages.ReceiveAsync(cancellationToken);
             }
 
             public Task CommitAsync(IKafkaMessage<string, string> message)

--- a/tests/Parallafka.Tests/KafkaTopicTestBase.cs
+++ b/tests/Parallafka.Tests/KafkaTopicTestBase.cs
@@ -31,7 +31,7 @@ namespace Parallafka.Tests
 
         protected IEnumerable<IKafkaMessage<string, string>> GenerateTestMessages(int count, int startNum = 1, bool duplicateKeys = true)
         {
-            return Enumerable.Range(startNum, count).Select(i => new KafkaMessage<string, string>(
+            return Enumerable.Range(startNum, count).Select(i => KafkaMessage.Create(
                     key: $"k{(duplicateKeys && i % 9 == 0 ? i - 1 : i)}",
                     value: $"Message {i}",
                     offset: null));

--- a/tests/Parallafka.Tests/MessageCommitterTests.cs
+++ b/tests/Parallafka.Tests/MessageCommitterTests.cs
@@ -21,13 +21,16 @@ namespace Parallafka.Tests
             var consumer = new Mock<IKafkaConsumer<string, string>>();
             var logger = new Mock<ILogger>();
             var commitState = new CommitState<string, string>(int.MaxValue, default);
-            var kafkaMessage = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 0));
+            var kafkaMessage = KafkaMessage.Create("key", "value", new RecordOffset(0, 0)).Wrapped();
             await commitState.EnqueueMessageAsync(kafkaMessage);
             var mc = new MessageCommitter<string, string>(
                 consumer.Object,
                 commitState,
                 logger.Object);
-            kafkaMessage.WasHandled = wasHandled;
+            if (wasHandled)
+            {
+                kafkaMessage.SetIsReadyToCommit();
+            }
 
             // when
             await mc.CommitNow(default);
@@ -51,9 +54,9 @@ namespace Parallafka.Tests
             var consumer = new Mock<IKafkaConsumer<string, string>>();
             var logger = new Mock<ILogger>();
             var commitState = new CommitState<string, string>(int.MaxValue, default);
-            var kafkaMessage1 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 1));
-            var kafkaMessage2 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 2));
-            var kafkaMessage3 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 3));
+            var kafkaMessage1 = KafkaMessage.Create("key", "value", new RecordOffset(0, 1)).Wrapped();
+            var kafkaMessage2 = KafkaMessage.Create("key", "value", new RecordOffset(0, 2)).Wrapped();
+            var kafkaMessage3 = KafkaMessage.Create("key", "value", new RecordOffset(0, 3)).Wrapped();
             await commitState.EnqueueMessageAsync(kafkaMessage1);
             await commitState.EnqueueMessageAsync(kafkaMessage2);
             await commitState.EnqueueMessageAsync(kafkaMessage3);
@@ -61,9 +64,8 @@ namespace Parallafka.Tests
                 consumer.Object,
                 commitState,
                 logger.Object);
-            kafkaMessage1.WasHandled = true;
-            kafkaMessage2.WasHandled = true;
-            kafkaMessage3.WasHandled = false;
+            kafkaMessage1.SetIsReadyToCommit();
+            kafkaMessage2.SetIsReadyToCommit();
 
             // when
             await mc.CommitNow(default);
@@ -82,9 +84,9 @@ namespace Parallafka.Tests
             var consumer = new Mock<IKafkaConsumer<string, string>>();
             var logger = new Mock<ILogger>();
             var commitState = new CommitState<string, string>(int.MaxValue, default);
-            var kafkaMessage1 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 1));
-            var kafkaMessage2 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 2));
-            var kafkaMessage3 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 3));
+            var kafkaMessage1 = KafkaMessage.Create("key", "value", new RecordOffset(0, 1)).Wrapped();
+            var kafkaMessage2 = KafkaMessage.Create("key", "value", new RecordOffset(0, 2)).Wrapped();
+            var kafkaMessage3 = KafkaMessage.Create("key", "value", new RecordOffset(0, 3)).Wrapped();
             await commitState.EnqueueMessageAsync(kafkaMessage1);
             await commitState.EnqueueMessageAsync(kafkaMessage2);
             await commitState.EnqueueMessageAsync(kafkaMessage3);
@@ -92,9 +94,9 @@ namespace Parallafka.Tests
                 consumer.Object,
                 commitState,
                 logger.Object);
-            kafkaMessage1.WasHandled = true;
-            kafkaMessage2.WasHandled = true;
-            kafkaMessage3.WasHandled = true;
+            kafkaMessage1.SetIsReadyToCommit();
+            kafkaMessage2.SetIsReadyToCommit();
+            kafkaMessage3.SetIsReadyToCommit();
 
             // when
             await mc.CommitNow(default);

--- a/tests/Parallafka.Tests/MessageCommitterTests.cs
+++ b/tests/Parallafka.Tests/MessageCommitterTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Parallafka.KafkaConsumer;
@@ -27,17 +26,13 @@ namespace Parallafka.Tests
             var mc = new MessageCommitter<string, string>(
                 consumer.Object,
                 commitState,
-                logger.Object,
-                TimeSpan.FromDays(1),
-                default);
+                logger.Object);
             kafkaMessage.WasHandled = wasHandled;
 
             // when
-            await mc.CommitNow();
-            mc.Complete();
-            await mc.Completion;
+            await mc.CommitNow(default);
 
-            this._output.WriteLine("Wait mc.Completion finished");
+            this._output.WriteLine("Wait mc.CommitNow finished");
 
             // then
             consumer.Verify(c => c.CommitAsync(It.Is<IKafkaMessage<string, string>>(r => r.Offset.Offset == 0 && r.Offset.Partition == 0)),
@@ -65,17 +60,13 @@ namespace Parallafka.Tests
             var mc = new MessageCommitter<string, string>(
                 consumer.Object,
                 commitState,
-                logger.Object,
-                TimeSpan.FromDays(1),
-                default);
+                logger.Object);
             kafkaMessage1.WasHandled = true;
             kafkaMessage2.WasHandled = true;
             kafkaMessage3.WasHandled = false;
 
             // when
-            await mc.CommitNow();
-            mc.Complete();
-            await mc.Completion;
+            await mc.CommitNow(default);
 
             // then
             consumer.Verify(c => c.CommitAsync(It.Is<IKafkaMessage<string, string>>(r => r.Offset.Equals(kafkaMessage2.Offset))), Times.Once);
@@ -100,17 +91,13 @@ namespace Parallafka.Tests
             var mc = new MessageCommitter<string, string>(
                 consumer.Object,
                 commitState,
-                logger.Object,
-                TimeSpan.FromDays(1),
-                default);
+                logger.Object);
             kafkaMessage1.WasHandled = true;
             kafkaMessage2.WasHandled = true;
             kafkaMessage3.WasHandled = true;
 
             // when
-            await mc.CommitNow();
-            mc.Complete();
-            await mc.Completion;
+            await mc.CommitNow(default);
 
             // then
             consumer.Verify(c => c.CommitAsync(It.Is<IKafkaMessage<string, string>>(r => r.Offset.Equals(kafkaMessage3.Offset))), Times.Once);

--- a/tests/Parallafka.Tests/MessageFinishedRouterTests.cs
+++ b/tests/Parallafka.Tests/MessageFinishedRouterTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
@@ -16,16 +13,16 @@ namespace Parallafka.Tests
         public async Task SameKeyMessagesAreSentToDataflowCorrectly()
         {
             // given
-            var mbk = new MessagesByKey<string, string>();
+            var mbk = new MessagesByKey<string, string>(default);
             var mfr = new MessageFinishedRouter<string, string>(mbk);
             var totalMessages = 5;
             var messages = Enumerable.Range(1, totalMessages)
-                .Select(i => new KafkaMessage<string, string>("key", "value", new RecordOffset(0, i)))
+                .Select(i => KafkaMessage.Create("key", "value", new RecordOffset(0, i)).Wrapped())
                 .ToList();
 
             var sentMessageCount = 0;
             IRecordOffset lastOffset = null;
-            var flow = new ActionBlock<IKafkaMessage<string, string>>(m =>
+            var flow = new ActionBlock<KafkaMessageWrapped<string, string>>(m =>
             {
                 lastOffset = m.Offset;
                 Interlocked.Increment(ref sentMessageCount);

--- a/tests/Parallafka.Tests/MessageRouterTests.cs
+++ b/tests/Parallafka.Tests/MessageRouterTests.cs
@@ -13,12 +13,12 @@ namespace Parallafka.Tests
         {
             // given
             var cs = new CommitState<string, string>(int.MaxValue, default);
-            var mbk = new MessagesByKey<string, string>();
+            var mbk = new MessagesByKey<string, string>(default);
             var mr = new MessageRouter<string, string>(cs, mbk, default);
-            var message1 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 0));
-            var message2 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 1));
+            var message1 = KafkaMessage.Create("key", "value", new RecordOffset(0, 0)).Wrapped();
+            var message2 = KafkaMessage.Create("key", "value", new RecordOffset(0, 1)).Wrapped();
             var messageCount = 0;
-            var flow = new ActionBlock<IKafkaMessage<string, string>>(m =>
+            var flow = new ActionBlock<KafkaMessageWrapped<string, string>>(m =>
             {
                 Interlocked.Increment(ref messageCount);
             });
@@ -41,12 +41,12 @@ namespace Parallafka.Tests
         {
             // given
             var cs = new CommitState<string, string>(int.MaxValue, default);
-            var mbk = new MessagesByKey<string, string>();
+            var mbk = new MessagesByKey<string, string>(default);
             var mr = new MessageRouter<string, string>(cs, mbk, default);
-            var message1 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 0));
-            var message2 = new KafkaMessage<string, string>("key", "value", new RecordOffset(0, 1));
+            var message1 = KafkaMessage.Create("key", "value", new RecordOffset(0, 0)).Wrapped();
+            var message2 = KafkaMessage.Create("key", "value", new RecordOffset(0, 1)).Wrapped();
             var messageCount = 0;
-            var flow = new ActionBlock<IKafkaMessage<string, string>>(m =>
+            var flow = new ActionBlock<KafkaMessageWrapped<string, string>>(m =>
             {
                 Interlocked.Increment(ref messageCount);
             });

--- a/tests/Parallafka.Tests/MessagesByKeyTests.cs
+++ b/tests/Parallafka.Tests/MessagesByKeyTests.cs
@@ -9,15 +9,15 @@ namespace Parallafka.Tests
         [Fact]
         public void GetNextMessageWorksCorrectly()
         {
-            var mbk = new MessagesByKey<string, string>();
-            var km1 = new KafkaMessage<string, string>("key1", "value");
-            var km2 = new KafkaMessage<string, string>("key2", "value");
-            var km3 = new KafkaMessage<string, string>("key3", "value");
+            var mbk = new MessagesByKey<string, string>(default);
+            var km1 = KafkaMessage.Create("key1", "value", new RecordOffset(0, 0)).Wrapped();
+            var km2 = KafkaMessage.Create("key2", "value", new RecordOffset(0, 1)).Wrapped();
+            var km3 = KafkaMessage.Create("key3", "value", new RecordOffset(0, 2)).Wrapped();
             Assert.True(mbk.TryAddMessageToHandle(km1));
             Assert.False(mbk.TryAddMessageToHandle(km1));
             Assert.True(mbk.TryAddMessageToHandle(km2));
 
-            IKafkaMessage<string, string> nextMessage;
+            KafkaMessageWrapped<string, string> nextMessage;
             Assert.True(mbk.TryGetNextMessageToHandle(km1, out nextMessage));
             Assert.Equal(km1, nextMessage);
             Assert.False(mbk.TryGetNextMessageToHandle(km1, out nextMessage));
@@ -31,8 +31,8 @@ namespace Parallafka.Tests
         [Fact]
         public void CompletionMessageWorksCorrectly()
         {
-            var mbk = new MessagesByKey<int, int>();
-            var kms = Enumerable.Range(1, 50).Select(i => new KafkaMessage<int, int>(i % 10, i)).ToList();
+            var mbk = new MessagesByKey<int, int>(default);
+            var kms = Enumerable.Range(1, 50).Select(i => KafkaMessage.Create(i % 10, i, new RecordOffset(0, i)).Wrapped()).ToList();
 
             foreach (var km in kms)
             {

--- a/tests/Parallafka.Tests/OrderGuarantee/OrderGuaranteeTestBase.cs
+++ b/tests/Parallafka.Tests/OrderGuarantee/OrderGuaranteeTestBase.cs
@@ -50,9 +50,10 @@ namespace Parallafka.Tests.OrderGuarantee
                 {
                     key = keys[keys.Count - 2];
                 }
-                messagesToSend.Add(new KafkaMessage<string, string>(
+                messagesToSend.Add(KafkaMessage.Create(
                     key: key,
-                    value: totalMessagesSent.ToString()));
+                    value: totalMessagesSent.ToString(),
+                    offset: new RecordOffset(0, totalMessagesSent)));
             }
 
             Task publishTask = this.Topic.PublishAsync(messagesToSend);

--- a/tests/Parallafka.Tests/OrderGuarantee/OrderGuaranteeTestBase.cs
+++ b/tests/Parallafka.Tests/OrderGuarantee/OrderGuaranteeTestBase.cs
@@ -61,7 +61,7 @@ namespace Parallafka.Tests.OrderGuarantee
             consumptionVerifier.AddSentMessages(messagesToSend);
 
             int totalReceived = 0;
-            CancellationTokenSource stopConsuming = new CancellationTokenSource();
+            using CancellationTokenSource stopConsuming = new CancellationTokenSource();
             await parallafka.ConsumeAsync(async msg =>
             {
                 var rng = new Random();

--- a/tests/Parallafka.Tests/ParallafkaBasicTests.cs
+++ b/tests/Parallafka.Tests/ParallafkaBasicTests.cs
@@ -167,21 +167,11 @@ namespace Parallafka.Tests
 
             public async Task<IKafkaMessage<TKey, TValue>> PollAsync(CancellationToken cancellationToken)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return null;
-                }
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (!_enumerator.MoveNext())
                 {
-                    try
-                    {
-                        await Task.Delay(-1, cancellationToken);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        return null;
-                    }
+                    await Task.Delay(-1, cancellationToken);
                 }
 
                 Interlocked.Increment(ref this._messagesQueued);

--- a/tests/Parallafka.Tests/ParallafkaBasicTests.cs
+++ b/tests/Parallafka.Tests/ParallafkaBasicTests.cs
@@ -20,8 +20,8 @@ namespace Parallafka.Tests
         public async Task MaxMessageQueuedIsObeyed(int partitions, int maxMessagesQueued, int maxDegreeOfParallelism)
         {
             // given
-            var stop = new CancellationTokenSource();
-            var giveUp = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var stop = new CancellationTokenSource();
+            using var giveUp = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var countTotalMessages = maxMessagesQueued * 2;
             var testCases = new TestCases(partitions, countTotalMessages);
             var consumer = new TestConsumer<string, string>(testCases.Messages);
@@ -81,7 +81,7 @@ namespace Parallafka.Tests
         public async Task ConsumedMessagesAndCommitsMatch(int partitions, int countTotalMessages, int maxDegreeOfParallelism)
         {
             // given
-            var stop = new CancellationTokenSource();
+            using var stop = new CancellationTokenSource();
             var testCases = new TestCases(partitions, countTotalMessages);
             var consumer = new TestConsumer<string, string>(testCases.Messages);
             var logger = new Mock<ILogger>();

--- a/tests/Parallafka.Tests/ParallafkaBasicTests.cs
+++ b/tests/Parallafka.Tests/ParallafkaBasicTests.cs
@@ -23,7 +23,7 @@ namespace Parallafka.Tests
             // given
             using var stop = new CancellationTokenSource();
             var stopToken = stop.Token;
-            using var giveUp = new CancellationTokenSource(TimeSpan.FromSeconds(300000));
+            using var giveUp = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var countTotalMessages = maxMessagesQueued * 2;
             var testCases = new TestCases(partitions, countTotalMessages);
             var consumer = new TestConsumer<string, string>(testCases.Messages);


### PR DESCRIPTION
This allows Parallafka clients to choose a commit delay for handling messages.  A delay of TimeSpan.Zero means the handled messages will commit as quickly as possible.  Any other delay means that commits will happen within that delay.  If the message queue is filled, commits occur ASAP.

This approach is more efficient than what it replaces:
1) There is no infinite loop that attempts to commit messages even when no messages were handled
2) All messages are committed within the delay timespan
3) The commit timer starts the moment a message handler completes

Note: includes code from #7 and #5 

Testing results:
Given:
- test suite of ~100k messages
- 50ms fake commit (no actual commit so test can re-run each time)
- Message handler is a Noop, simply logs the message count, time

Run times:
1000 MaxQueuedMessages: ~9 seconds, 75 commits
100_000 MaxQueuedMessages: ~6 seconds, 3 commits

